### PR TITLE
duplicated method generateGit

### DIFF
--- a/lib/generators/app/index.js
+++ b/lib/generators/app/index.js
@@ -185,7 +185,7 @@ Generator.prototype.generateGit = function generateGit() {
  * Generate Travis CI related files
  */
 
-Generator.prototype.generateGit = function generateGit() {
+Generator.prototype.generateCI = function generateCI() {
   this.dest.write(".travis.yml", this.src.read(".travis.yml"));
 };
 

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -29,7 +29,11 @@ describe("bbb generator", function () {
       "index.html",
       "app/config.js",
       "app/app.js",
-      "app/main.js"
+      "app/main.js",
+      ".gitignore",
+      ".travis.yml",
+      ".editorconfig",
+      "package.json"
     ];
 
     helpers.mockPrompt(this.app);


### PR DESCRIPTION
This would cause the first method will not be executed. Thus change the latter to correct name to ensure all intended steps are done.
